### PR TITLE
Add keybindings to accentuate how I use VSpaceCode outside of the editor

### DIFF
--- a/macintacos/README.md
+++ b/macintacos/README.md
@@ -2,10 +2,13 @@
 
 There are two files that make up my configuration for ease of iteration:
 
-1. `vspacecode-config.json` - contains actual VSpaceCode overrides
+1. `vspacecode-config.json` - contains actual VSpaceCode overrides.
 2. `other-config.json` - contains "other settings" needed to make sure the aforementioned VSpaceCode overrides work as expected.
+3. `keybindings.json` - contains keybindings that make more "escape hatches" possible so that you can use `SPC` to invoke VSpaceCode pretty much anywhere.
 
 ## Setup
+
+### Extension Settings
 
 The actual overrides are in `vspacecode-config.json`, however there is some additional settings/extensions needed to get every command to behave the way I expect which are defined in `other-config.json`.
 
@@ -13,9 +16,20 @@ The actual overrides are in `vspacecode-config.json`, however there is some addi
 - I use [Settings Cycler](https://marketplace.visualstudio.com/items?itemName=hoovercj.vscode-settings-cycler) for cycling through line number types; there's probably an easier solution for this but I haven't found it.
 - There's some minor configuration for `whichkey` (I added a delay because if I know the chord I don't need the menu to render really).
 
+### Keyboard Settings
+
+You can use `keybindings.json` to augment your existing keybindings. Because I use just the `SPC` key to invoke `vspacecode.space`, I need to have various "escape hatches" to get out of places where VSCode interprets you hitting the `SPC` key to mean "insert a space" instead of "invoke VSpaceCode". With this set of keybindings:
+
+- Hitting `tab`/`shift-tab` will kick you to the next/previous "group". In this implementation, you can think of a "group" to also mean the sidebar, which means that using `tab`/`shift+tab` will also navigate you out of the sidebar. Unfortunately this does not include the bottom panel. These keys do the same when you're in `normal` mode in VSCodeVim.
+- Hitting `escape` _for the most part_ will get you out of whatever text field you're in an put you somewhere that, when you hit `SPC`, you'll invoke VSpaceCode. This doesn't have a 100% hit rate.
+- `ctrl+space` is there to invoke the extension in case you really can't get out of where you're currently at. Currently it doesn't seem to work in the terminal, but I think that's a bug.
+
+Unfortunately even with these keybindings, I haven't been able to achieve 100% reliability. Please vote for this issue if you'd like this to be a bit "simpler" and have a global "lose focus" command: https://github.com/microsoft/vscode/issues/103845
+
 ## Caveats
 
 - I don't use `edmagit`, so my `SPC g ...` commands are custom made and will likely stay that way. I lived without `magit` for a bit too long when I switched to VSCode, so I just got used to my Sublime Merge workflow.
+- As mentioned in the Setup, I use VSCodeVim, and a few things in my config is expecting that extension to be in use.
 - I use _probably_ too many extensions, so you're going to have to do some downloading if you want to steal this whole config.
 
 Copy/paste at your own risk.

--- a/macintacos/keybindings.json
+++ b/macintacos/keybindings.json
@@ -1,0 +1,219 @@
+[
+  {
+    "key": "ctrl+space",
+    "command": "vspacecode.space",
+    "when": "!whichkeyActive && inputFocus && !editorTextFocus"
+  },
+  {
+    "key": "space",
+    "command": "vspacecode.space",
+    "when": "!whichkeyActive && !inputFocus"
+  },
+  {
+    "key": "escape",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "!editorTextFocus && !whichKeyActive && inputFocus && !terminalFocus"
+  },
+  {
+    "key": "escape",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "!editorTextFocus && !whichKeyActive && panelFocus && !terminalFocus"
+  },
+  {
+    "key": "shift+escape",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.explorer'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.scm'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.debug'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extensions'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.test'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.github-pull-requests'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.bookmarks'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.gistpad'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.todo-tree-container'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.project-manager'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.dockerView'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.kubernetesView'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusFirstEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.mongoDB'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.explorer'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.scm'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.debug'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extensions'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.github-pull-requests'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "inKeybindings"
+  },
+  {
+    "command": "workbench.action.focusLastEditorGroup",
+    "key": "shift+tab",
+    "when": "inKeybindings && activeEditorGroupLast && !sideBarVisible"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.bookmarks'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.gistpad'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.todo-tree-container'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.project-manager'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.dockerView'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.kubernetesView'"
+  },
+  {
+    "key": "shift+tab",
+    "command": "workbench.action.focusLastEditorGroup",
+    "when": "sideBarFocus && activeViewlet == 'workbench.view.extension.mongoDB'"
+  },
+  {
+    "command": "workbench.action.focusNextGroup",
+    "key": "tab",
+    "when": "editorFocus && vim.mode == 'Normal'"
+  },
+  {
+    "key": "tab",
+    "command": "workbench.action.focusNextGroup",
+    "when": "inKeybindings"
+  },
+  {
+    "command": "workbench.action.focusPreviousGroup",
+    "key": "shift+tab",
+    "when": "editorFocus && vim.mode == 'Normal' && activeEditorGroupIndex != 1"
+  },
+  {
+    "command": "workbench.action.focusSideBar",
+    "key": "shift+tab",
+    "when": "editorFocus && vim.mode == 'Normal' && activeEditorGroupIndex == 1"
+  },
+  {
+    "command": "workbench.action.focusSideBar",
+    "key": "shift+tab",
+    "when": "inKeybindings && activeEditorGroupIndex == 1 && sideBarVisible"
+  },
+  {
+    "command": "workbench.action.focusSideBar",
+    "key": "tab",
+    "when": "editorFocus && vim.mode == 'Normal' && activeEditorGroupLast && sideBarVisible"
+  },
+  {
+    "command": "workbench.action.focusSideBar",
+    "key": "tab",
+    "when": "inKeybindings && activeEditorGroupLast && sideBarVisible"
+  },
+  {
+    "key": "ctrl+tab",
+    "command": "workbench.action.nextPanelView",
+    "when": "panelFocus"
+  },
+  {
+    "key": "shift+ctrl+tab",
+    "command": "workbench.action.previousPanelView",
+    "when": "panelFocus"
+  },
+  {
+    "key": "ctrl+tab",
+    "command": "workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup"
+  },
+  {
+    "command": "workbench.action.terminal.focus",
+    "key": "cmd+'"
+  },
+  {
+    "command": "workbench.action.terminal.toggleTerminal",
+    "key": "ctrl+'"
+  }
+]

--- a/macintacos/vspacecode-config.json
+++ b/macintacos/vspacecode-config.json
@@ -839,7 +839,7 @@
           ],
           "key": "h",
           "name": "...to the left",
-          "type": "command"
+          "type": "commands"
         },
         {
           "commands": [
@@ -848,7 +848,7 @@
           ],
           "key": "j",
           "name": "...to below",
-          "type": "command"
+          "type": "commands"
         },
         {
           "commands": [
@@ -857,7 +857,7 @@
           ],
           "key": "k",
           "name": "...to above",
-          "type": "command"
+          "type": "commands"
         }
       ],
       "keys": ["w", "f"],


### PR DESCRIPTION
As the title suggests, I noticed that there was a missing piece for my config; how I was invoking VSpaceCode outside of the editor. Whereas the editor is more straightforward thanks to Vim, getting it to work outside of the editor is a tad more tricky, and these keybindings get me like 90% of the way there.

There was also a small issue with my `SPC w f j/k/h` commands that are now fixed.